### PR TITLE
Migrate to TensorFlow r1.0 and Python 3

### DIFF
--- a/ByteNet/model.py
+++ b/ByteNet/model.py
@@ -1,5 +1,6 @@
-import tensorflow as tf
 import numpy as np
+import tensorflow as tf
+
 from ByteNet import ops
 
 class Byte_net_model:
@@ -30,8 +31,8 @@ class Byte_net_model:
 
 		if 'source_mask_chars' in options:
 			# FOR EMBEDDING ONLY THE INPUT SENTENCE BEFORE THE PADDING
-			# THE OUTPUT NETWORK WHOULD BE CONDITIONED ONLY UPTO INPUT LENGTH
-			# ALSO LOSS NEEDS TO BE CALCULATED UPTO TARGET SENTENCE
+			# THE OUTPUT NETWORK WOULD BE CONDITIONED ONLY UP TO INPUT LENGTH
+			# ALSO LOSS NEEDS TO BE CALCULATED UP TO TARGET SENTENCE
 			input_sentence_mask = np.ones( 
 				(options['n_source_quant'], 2 * options['residual_channels']), dtype = 'float32')
 
@@ -254,7 +255,7 @@ class Byte_net_model:
 	def decoder(self, input_, encoder_embedding = None):
 		options = self.options
 		curr_input = input_
-		if encoder_embedding != None:
+		if encoder_embedding is not None:
 			# CONDITION WITH ENCODER EMBEDDING FOR THE TRANSLATION MODEL
 			curr_input = tf.concat(2, [input_, encoder_embedding])
 			print("Decoder Input", curr_input)
@@ -273,7 +274,7 @@ class Byte_net_model:
 
 
 
-	def encode_layer(self, input_, dilation, layer_no, last_layer = False):
+	def encode_layer(self, input_, dilation, layer_no):
 		options = self.options
 		relu1 = tf.nn.relu(input_, name = 'enc_relu1_layer{}'.format(layer_no))
 		conv1 = ops.conv1d(relu1, options['residual_channels'], name = 'enc_conv1d_1_layer{}'.format(layer_no))

--- a/ByteNet/model.py
+++ b/ByteNet/model.py
@@ -138,10 +138,10 @@ class Byte_net_model:
 		source_embedding = tf.nn.embedding_lookup(self.w_source_embedding, source_sentence, name = "source_embedding")
 		decoder_output = self.decoder(source_embedding)
 		loss = self.loss(decoder_output, target_sentence)
-		
+
 		tf.summary.scalar('loss', loss)
 
-		flat_logits = tf.reshape( decoder_output, [-1, options['n_target_quant']])
+		flat_logits = tf.reshape(decoder_output, [-1, options['n_target_quant']])
 		prediction = tf.argmax(flat_logits, 1)
 		
 		variables = tf.trainable_variables()
@@ -244,7 +244,7 @@ class Byte_net_model:
 		dilated_conv = ops.dilated_conv1d(relu2, options['residual_channels'], 
 			dilation, options['decoder_filter_width'],
 			causal = True, 
-			name = "dec_dilated_conv_laye{}".format(layer_no)
+			name = "dec_dilated_conv_layer{}".format(layer_no)
 			)
 		
 		relu3 = tf.nn.relu(dilated_conv, name = 'dec_relu3_layer{}'.format(layer_no))
@@ -262,11 +262,10 @@ class Byte_net_model:
 			
 
 		for layer_no, dilation in enumerate(options['decoder_dilations']):
-			layer_output = self.decode_layer(curr_input, dilation, layer_no)
-			curr_input = layer_output
+			curr_input = self.decode_layer(curr_input, dilation, layer_no)
 
 
-		processed_output = ops.conv1d(tf.nn.relu(layer_output), 
+		processed_output = ops.conv1d(tf.nn.relu(curr_input),
 			options['n_target_quant'], 
 			name = 'decoder_post_processing')
 

--- a/ByteNet/model.py
+++ b/ByteNet/model.py
@@ -1,6 +1,6 @@
 import tensorflow as tf
 import numpy as np
-import ops
+from ByteNet import ops
 
 class Byte_net_model:
 	def __init__(self, options):
@@ -91,7 +91,7 @@ class Byte_net_model:
 
 		loss = self.loss(decoder_output, target_sentence2)
 
-		tf.scalar_summary('LOSS', loss)
+		tf.summary.scalar('loss', loss)
 
 		flat_logits = tf.reshape( decoder_output, [-1, options['n_target_quant']])
 		prediction = tf.argmax(flat_logits, 1)
@@ -138,7 +138,7 @@ class Byte_net_model:
 		decoder_output = self.decoder(source_embedding)
 		loss = self.loss(decoder_output, target_sentence)
 		
-		tf.scalar_summary('LOSS', loss)
+		tf.summary.scalar('loss', loss)
 
 		flat_logits = tf.reshape( decoder_output, [-1, options['n_target_quant']])
 		prediction = tf.argmax(flat_logits, 1)
@@ -257,7 +257,7 @@ class Byte_net_model:
 		if encoder_embedding != None:
 			# CONDITION WITH ENCODER EMBEDDING FOR THE TRANSLATION MODEL
 			curr_input = tf.concat(2, [input_, encoder_embedding])
-			print "Decoder Input", curr_input
+			print("Decoder Input", curr_input)
 			
 
 		for layer_no, dilation in enumerate(options['decoder_dilations']):

--- a/ByteNet/model.py
+++ b/ByteNet/model.py
@@ -275,7 +275,7 @@ class Byte_net_model:
 
 
 		processed_output = ops.conv1d(
-			curr_input,
+			tf.nn.relu(curr_input),
 			options['n_target_quant'], 
 			name = 'decoder_post_processing')
 

--- a/ByteNet/model.py
+++ b/ByteNet/model.py
@@ -275,7 +275,7 @@ class Byte_net_model:
 
 
 		processed_output = ops.conv1d(
-			tf.nn.relu(curr_input),
+			curr_input,
 			options['n_target_quant'], 
 			name = 'decoder_post_processing')
 

--- a/ByteNet/ops.py
+++ b/ByteNet/ops.py
@@ -35,8 +35,7 @@ def conv1d(input_,
 
 		scale = he_uniform(filter_width, in_dim)
 		w = tf.get_variable('W', [filter_width, in_dim, output_channels],
-			initializer = tf.random_uniform_initializer(minval=-scale, maxval=scale),
-			trainable   = True)
+			initializer = tf.random_uniform_initializer(minval=-scale, maxval=scale))
 		b = tf.get_variable('b', [output_channels], initializer=tf.constant_initializer(0.0))
 
 		return tf.nn.conv1d(input_, w, stride = stride, padding = 'SAME') + b

--- a/ByteNet/ops.py
+++ b/ByteNet/ops.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 
-def time_to_batch(value, dilation, name=None):
-	# FOR DILATED CONVOLUTION, code adpated from tensorflow-wavenet
+def time_to_batch(value, dilation):
+	# FOR DILATED CONVOLUTION, code adapted from tensorflow-wavenet
 	with tf.name_scope('time_to_batch'):
 		shape = value.get_shape()
 		shape = [int(s) for s in shape]
@@ -11,14 +11,14 @@ def time_to_batch(value, dilation, name=None):
 		transposed = tf.transpose(reshaped, perm=[1, 0, 2])
 		return tf.reshape(transposed, [shape[0] * dilation, -1, shape[2]])
 
-def batch_to_time(value, dilation, name=None):
+def batch_to_time(value, dilation):
 	with tf.name_scope('batch_to_time'):
 		shape = value.get_shape()
 		shape = [int(s) for s in shape]
 		prepared = tf.reshape(value, [dilation, -1, shape[2]])
 		transposed = tf.transpose(prepared, perm=[1, 0, 2])
 		return tf.reshape(transposed,
-						  [(shape[0]/dilation), -1, shape[2]])
+						  [int(shape[0] / dilation), -1, shape[2]])
 
 def conv1d(input_, output_channels, 
 	filter_width = 1, stride = 1, stddev=0.02,
@@ -42,7 +42,6 @@ def dilated_conv1d(input_, output_channels, dilation,
 		padding = [[0, 0], [(filter_width - 1) * dilation, 0], [0, 0]]
 		padded = tf.pad(input_, padding)
 	else:
-		
 		padding = [[0, 0], [(filter_width - 1) * dilation/2, (filter_width - 1) * dilation/2], [0, 0]]
 		padded = tf.pad(input_, padding)
 	
@@ -57,7 +56,3 @@ def dilated_conv1d(input_, output_channels, dilation,
 	result = tf.slice(restored,[0, 0, 0],[-1, int(input_.get_shape()[1]), -1])
 	
 	return result
-
-
-
-

--- a/ByteNet/ops.py
+++ b/ByteNet/ops.py
@@ -19,23 +19,18 @@ def batch_to_time(value, dilation):
 		return tf.reshape(transposed,
 						  [int(batch_size / dilation), -1, embedding_size])
 
-# See http://arxiv.org/abs/1502.01852
-def he_uniform(filter_width, in_dim, scale=1):
-	fan_in = filter_width * in_dim
-	return np.sqrt(1. * scale / fan_in)
-
 def conv1d(input_,
 		   output_channels,
 		   filter_width = 1,
 		   stride       = 1,
+		   stddev       = 0.02,
 		   name         = 'conv1d'
 		  ):
 	with tf.variable_scope(name):
 		in_dim = input_.get_shape().as_list()[-1]
 
-		scale = he_uniform(filter_width, in_dim)
 		w = tf.get_variable('W', [filter_width, in_dim, output_channels],
-			initializer = tf.random_uniform_initializer(minval=-scale, maxval=scale))
+			initializer = tf.truncated_normal_initializer(stddev=stddev))
 		b = tf.get_variable('b', [output_channels], initializer=tf.constant_initializer(0.0))
 
 		return tf.nn.conv1d(input_, w, stride = stride, padding = 'SAME') + b

--- a/ByteNet/ops.py
+++ b/ByteNet/ops.py
@@ -42,15 +42,14 @@ def conv1d(input_,
 
 def dilated_conv1d(input_, output_channels, dilation, 
 	filter_width = 1, causal = False, name = 'dilated_conv'):
-	
-	
+
 	if causal:
 		# padding for masked convolution
 		padding = [[0, 0], [(filter_width - 1) * dilation, 0], [0, 0]]
-		padded = tf.pad(input_, padding)
 	else:
 		padding = [[0, 0], [(filter_width - 1) * dilation/2, (filter_width - 1) * dilation/2], [0, 0]]
-		padded = tf.pad(input_, padding)
+
+	padded = tf.pad(input_, padding)
 	
 	if dilation > 1:
 		transformed = time_to_batch(padded, dilation)

--- a/ByteNet/ops.py
+++ b/ByteNet/ops.py
@@ -41,8 +41,7 @@ def conv1d(input_,
 			trainable   = True)
 		b = tf.get_variable('b', [output_channels], initializer=tf.constant_initializer(0.0))
 
-		conv = tf.nn.conv1d(input_, w, stride = stride, padding = 'SAME')
-		return tf.reshape(tf.nn.bias_add(conv, b), conv.get_shape())
+		return tf.nn.conv1d(input_, w, stride = stride, padding = 'SAME') + b
 
 def dilated_conv1d(input_, output_channels, dilation, 
 	filter_width = 1, causal = False, name = 'dilated_conv'):

--- a/ByteNet/ops.py
+++ b/ByteNet/ops.py
@@ -4,8 +4,7 @@ import tensorflow as tf
 def time_to_batch(value, dilation):
 	# FOR DILATED CONVOLUTION, code adapted from tensorflow-wavenet
 	with tf.name_scope('time_to_batch'):
-		shape = value.get_shape()
-		shape = [int(s) for s in shape]
+		shape = value.get_shape().as_list()
 		pad_elements = dilation - 1 - (int(shape[1]) + dilation - 1) % dilation
 		padded = tf.pad(value, [[0, 0], [0, pad_elements], [0, 0]])
 		reshaped = tf.reshape(padded, [-1, dilation, shape[2]])
@@ -14,8 +13,7 @@ def time_to_batch(value, dilation):
 
 def batch_to_time(value, dilation):
 	with tf.name_scope('batch_to_time'):
-		shape = value.get_shape()
-		shape = [int(s) for s in shape]
+		shape = value.get_shape().as_list()
 		prepared = tf.reshape(value, [dilation, -1, shape[2]])
 		transposed = tf.transpose(prepared, perm=[1, 0, 2])
 		return tf.reshape(transposed,

--- a/ByteNet/ops.py
+++ b/ByteNet/ops.py
@@ -62,7 +62,7 @@ def dilated_conv1d(input_, output_channels, dilation,
 	else:
 		restored = conv1d(padded, output_channels, filter_width, name = name)
 
-	
+	# Remove excess elements at the end
 	result = tf.slice(restored,[0, 0, 0],[-1, int(input_.get_shape()[1]), -1])
 	
 	return result

--- a/ByteNet/ops.py
+++ b/ByteNet/ops.py
@@ -4,20 +4,20 @@ import tensorflow as tf
 def time_to_batch(value, dilation):
 	# FOR DILATED CONVOLUTION, code adapted from tensorflow-wavenet
 	with tf.name_scope('time_to_batch'):
-		shape = value.get_shape().as_list()
-		pad_elements = dilation - 1 - (int(shape[1]) + dilation - 1) % dilation
+		(batch_size, sample_size, embedding_size) = value.get_shape().as_list()
+		pad_elements = dilation - 1 - (sample_size + dilation - 1) % dilation
 		padded = tf.pad(value, [[0, 0], [0, pad_elements], [0, 0]])
-		reshaped = tf.reshape(padded, [-1, dilation, shape[2]])
+		reshaped = tf.reshape(padded, [-1, dilation, embedding_size])
 		transposed = tf.transpose(reshaped, perm=[1, 0, 2])
-		return tf.reshape(transposed, [shape[0] * dilation, -1, shape[2]])
+		return tf.reshape(transposed, [batch_size * dilation, -1, embedding_size])
 
 def batch_to_time(value, dilation):
 	with tf.name_scope('batch_to_time'):
-		shape = value.get_shape().as_list()
-		prepared = tf.reshape(value, [dilation, -1, shape[2]])
+		(batch_size, sample_size, embedding_size) = value.get_shape().as_list()
+		prepared = tf.reshape(value, [dilation, -1, embedding_size])
 		transposed = tf.transpose(prepared, perm=[1, 0, 2])
 		return tf.reshape(transposed,
-						  [int(shape[0] / dilation), -1, shape[2]])
+						  [int(batch_size / dilation), -1, embedding_size])
 
 # See http://arxiv.org/abs/1502.01852
 def he_uniform(filter_width, in_dim, scale=1):

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The model applies dilated 1d convolutions on the sequential data, layer by layer
 5. Number of residual channels 512 (Configurable in model_config.py).
 
 ## Requirements
-- Python 2.7.6
-- Tensorflow >= rc0.10
+- Python 3.3+
+- TensorFlow r1.0+
 
 ## Datasets
 - The character generation model has been trained on [Shakespeare text][4]. I have included the text file in the repository ```Data/shakespeare.txt```.

--- a/data_loader.py
+++ b/data_loader.py
@@ -1,7 +1,6 @@
-import os
+import numpy as np
 from os import listdir
 from os.path import isfile, join
-import numpy as np
 
 class Data_Loader:
 	def __init__(self, options):
@@ -14,30 +13,30 @@ class Data_Loader:
 				self.max_sentences = options['max_sentences']
 
 			with open(source_file) as f:
-				self.source_lines = f.read().decode("utf-8").split('\n')
+				self.source_lines = f.read().split('\n')
 			with open(target_file) as f:
-				self.target_lines = f.read().decode("utf-8").split('\n')
+				self.target_lines = f.read().split('\n')
 
 			if self.max_sentences:
 				self.source_lines = self.source_lines[0:self.max_sentences]
 				self.target_lines = self.target_lines[0:self.max_sentences]
 
-			print "Source Sentences", len(self.source_lines)
-			print "Target Sentences", len(self.target_lines)
+			print("Source Sentences", len(self.source_lines))
+			print("Target Sentences", len(self.target_lines))
 
 			self.bucket_quant = options['bucket_quant']
 			self.source_vocab = self.build_vocab(self.source_lines)
 			self.target_vocab = self.build_vocab(self.target_lines)
 
-			print "SOURCE VOCAB SIZE", len(self.source_vocab)
-			print "TARGET VOCAB SIZE", len(self.target_vocab)
+			print("SOURCE VOCAB SIZE", len(self.source_vocab))
+			print("TARGET VOCAB SIZE", len(self.target_vocab))
 		
 		elif options['model_type'] == 'generator':
 			dir_name = options['dir_name']
 			files = [ join(dir_name, f) for f in listdir(dir_name) if ( isfile(join(dir_name, f)) and ('.txt' in f) ) ]
 			text = []
 			for f in files:
-				text += list(open(f).read().decode("utf-8"))
+				text += list(open(f).read())
 			
 			for index, item in enumerate(text):
 				text[index] = ord(text[index])
@@ -64,10 +63,10 @@ class Data_Loader:
 		frequent_keys = [ (-len(buckets[key]), key) for key in buckets ]
 		frequent_keys.sort()
 
-		print "Source", self.inidices_to_string( buckets[ frequent_keys[3][1] ][5][0], self.source_vocab)
-		print "Target", self.inidices_to_string( buckets[ frequent_keys[3][1] ][5][1], self.target_vocab)
+		print("Source", self.inidices_to_string( buckets[ frequent_keys[3][1] ][5][0], self.source_vocab))
+		print("Target", self.inidices_to_string( buckets[ frequent_keys[3][1] ][5][1], self.target_vocab))
 		
-		print len(frequent_keys)
+		print(len(frequent_keys))
 		return buckets, self.source_vocab, self.target_vocab, frequent_keys
 
 
@@ -106,7 +105,7 @@ class Data_Loader:
 				buckets[new_length] = [(source_lines[i], target_lines[i])]
 
 			if i%1000 == 0:
-				print "Loading", i
+				print("Loading", i)
 			
 		return buckets
 

--- a/generate.py
+++ b/generate.py
@@ -9,7 +9,7 @@ def main():
 	parser = argparse.ArgumentParser()
 	
 	
-	parser.add_argument('--model_path', type=str, default="Data/Models/model_epoch_6.ckpt",
+	parser.add_argument('--model_path', type=str, default="Data/Models/model_epoch_0.ckpt",
                        help='Pre-Trained Model Path')
 	parser.add_argument('--data_dir', type=str, default='Data',
                        help='Data Directory')
@@ -24,7 +24,7 @@ def main():
 
 	args = parser.parse_args()
 	
-	config = model_config.config
+	config = model_config.predictor_config
 
 	model_options = {
 		'n_source_quant' : config['n_source_quant'],
@@ -49,7 +49,7 @@ def main():
 
 	
 	input_batch = seed_
-	print "INPUT", input_batch
+	print("INPUT", input_batch)
 	for i in range(0, args.num_char - len(args.seed)):
 		
 		prediction, probs = sess.run( [generator['prediction'], generator['probs']], 
@@ -63,9 +63,9 @@ def main():
 		res = utils.list_to_string(input_batch[0, 0 : i + len(args.seed) + 1])
 		
 		if i % 100 == 0:
-			print res
+			print(res)
 
-		with open(args.output_file, 'wb') as f:
+		with open(args.output_file, 'w') as f:
 			f.write(res)
 
 

--- a/train_generator.py
+++ b/train_generator.py
@@ -1,10 +1,11 @@
-import tensorflow as tf
-import numpy as np
+import os
 import argparse
-import model_config
-import data_loader
-from ByteNet import model
+import tensorflow as tf
+
 import utils
+import data_loader
+import model_config
+from ByteNet import model
 
 def main():
 	parser = argparse.ArgumentParser()
@@ -47,7 +48,7 @@ def main():
 		beta1 = args.beta1).minimize(bn_tensors['loss'], var_list=bn_tensors['variables'])
 
 	sess = tf.InteractiveSession()
-	tf.initialize_all_variables().run()
+	tf.global_variables_initializer().run()
 	saver = tf.train.Saver()
 
 	if args.resume_model:
@@ -55,25 +56,28 @@ def main():
 
 	dl = data_loader.Data_Loader({'model_type' : 'generator', 'dir_name' : args.data_dir})
 	text_samples = dl.load_generator_data( config['sample_size'])
-	print text_samples.shape
+	print(text_samples.shape)
+
+	models_path = "Data/Models/"
+	if not os.path.exists(models_path): os.makedirs(models_path)
 
 	for i in range(args.max_epochs):
 		batch_no = 0
 		batch_size = args.batch_size
 		while (batch_no+1) * batch_size < text_samples.shape[0]:
 			text_batch = text_samples[batch_no*batch_size : (batch_no + 1)*batch_size, :]
-			_, loss, prediction = sess.run( [optim, bn_tensors['loss'], bn_tensors['prediction']], feed_dict = {
+			_, loss, prediction = sess.run([optim, bn_tensors['loss'], bn_tensors['prediction']], feed_dict = {
 				bn_tensors['sentence'] : text_batch
 				})
-			print "-------------------------------------------------------"
-			print utils.list_to_string(prediction)
-			print "Loss", i, batch_no, loss
-			print "********************************************************"
+			print("-------------------------------------------------------")
+			print(utils.list_to_string(prediction))
+			print("Loss", i, batch_no, loss)
+			print("********************************************************")
 			# print prediction
 			batch_no += 1
 			
-			if (batch_no % 500) == 0:
-				save_path = saver.save(sess, "Data/Models/model_epoch_{}.ckpt".format(i))
+			if batch_no % 500 == 0:
+				save_path = saver.save(sess, models_path + "model_epoch_{}.ckpt".format(i))
 
 if __name__ == '__main__':
 	main()

--- a/train_generator.py
+++ b/train_generator.py
@@ -38,12 +38,11 @@ def main():
 		'batch_size' : args.batch_size,
 	}
 
-	byte_net = model.Byte_net_model( model_options )
+	byte_net = model.Byte_net_model(model_options)
 	bn_tensors = byte_net.build_prediction_model()
 
-	optim = tf.train.AdamOptimizer(
-		args.learning_rate, 
-		beta1 = args.beta1).minimize(bn_tensors['loss'], var_list=bn_tensors['variables'])
+	optim = tf.train.AdamOptimizer(args.learning_rate, beta1 = args.beta1) \
+		.minimize(bn_tensors['loss'], var_list=bn_tensors['variables'])
 
 	sess = tf.InteractiveSession()
 	tf.global_variables_initializer().run()
@@ -62,20 +61,21 @@ def main():
 	for i in range(args.max_epochs):
 		batch_no = 0
 		batch_size = args.batch_size
-		while (batch_no+1) * batch_size < text_samples.shape[0]:
+		while (batch_no + 1) * batch_size < text_samples.shape[0]:
 			text_batch = text_samples[batch_no*batch_size : (batch_no + 1)*batch_size, :]
 			_, loss, prediction = sess.run([optim, bn_tensors['loss'], bn_tensors['prediction']], feed_dict = {
 				bn_tensors['sentence'] : text_batch
 			})
+
 			print("-------------------------------------------------------")
 			print(utils.list_to_string(prediction))
 			print("Loss", i, batch_no, loss)
 			print("********************************************************")
-			# print prediction
+
 			batch_no += 1
 			
 			if batch_no % 500 == 0:
-				save_path = saver.save(sess, models_path + "model_epoch_{}.ckpt".format(i))
+				saver.save(sess, models_path + "model_epoch_{}.ckpt".format(i))
 
 if __name__ == '__main__':
 	main()

--- a/train_generator.py
+++ b/train_generator.py
@@ -54,7 +54,7 @@ def main():
 		saver.restore(sess, args.resume_model)
 
 	dl = data_loader.Data_Loader({'model_type' : 'generator', 'dir_name' : args.data_dir})
-	text_samples = dl.load_generator_data( config['sample_size'])
+	text_samples = dl.load_generator_data(config['sample_size'])
 	print(text_samples.shape)
 
 	models_path = "Data/Models/"

--- a/train_generator.py
+++ b/train_generator.py
@@ -22,8 +22,6 @@ def main():
 	parser.add_argument('--data_dir', type=str, default='Data',
                        help='Data Directory')
 	
-
-
 	args = parser.parse_args()
 	
 	# model_config = json.loads( open('model_config.json').read() )
@@ -68,7 +66,7 @@ def main():
 			text_batch = text_samples[batch_no*batch_size : (batch_no + 1)*batch_size, :]
 			_, loss, prediction = sess.run([optim, bn_tensors['loss'], bn_tensors['prediction']], feed_dict = {
 				bn_tensors['sentence'] : text_batch
-				})
+			})
 			print("-------------------------------------------------------")
 			print(utils.list_to_string(prediction))
 			print("Loss", i, batch_no, loss)

--- a/train_translator.py
+++ b/train_translator.py
@@ -1,8 +1,8 @@
-import tensorflow as tf
-import numpy as np
 import argparse
-import model_config
+import tensorflow as tf
+
 import data_loader
+import model_config
 from ByteNet import model
 
 def main():
@@ -23,7 +23,7 @@ def main():
                        help='Source File')
 	parser.add_argument('--target_file', type=str, default='Data/MachineTranslation/news-commentary-v11.de-en.en',
                        help='Target File')
-	
+
 
 
 	args = parser.parse_args()
@@ -62,7 +62,7 @@ def main():
 		last_saved_model_path = args.resume_model
 
 	
-	print "Number Of Buckets", len(buckets)
+	print("Number Of Buckets", len(buckets))
 
 	for i in range(1, args.max_epochs):
 		cnt = 0
@@ -70,12 +70,12 @@ def main():
 			cnt += 1
 			
 
-			print "KEY", cnt, key
+			print("KEY", cnt, key)
 			if key > 400:
 				continue
 			
 			if len(buckets[key]) < args.batch_size:
-				print "BUCKET TOO SMALL", key
+				print("BUCKET TOO SMALL", key)
 				continue
 
 			sess = tf.InteractiveSession()
@@ -113,32 +113,29 @@ def main():
 					feed_dict = {
 						bn_tensors['source_sentence'] : source,
 						bn_tensors['target_sentence'] : target,
-
 					})
 				
 				train_writer.add_summary(summary, batch_no * (cnt + 1))
-				print "Loss", loss, batch_no, len(buckets[key])/batch_size, i, cnt, key
+				print("Loss", loss, batch_no, len(buckets[key])/batch_size, i, cnt, key)
 				
-				print "******"
-				print "Source ", dl.inidices_to_string(source[0], source_vocab)
-				print "---------"
-				print "Target ", dl.inidices_to_string(target[0], target_vocab)
-				print "----------"
-				print "Prediction ",dl.inidices_to_string(prediction[0:key], target_vocab)
-				print "******"
+				print("******")
+				print("Source ", dl.inidices_to_string(source[0], source_vocab))
+				print("---------")
+				print("Target ", dl.inidices_to_string(target[0], target_vocab))
+				print("----------")
+				print("Prediction ",dl.inidices_to_string(prediction[0:key], target_vocab))
+				print("******")
 				
 				batch_no += 1
 				if batch_no % 1000 == 0:
-					save_path = saver.save(sess, "Data/Models/model_translation_epoch_{}_{}.ckpt".format(i, cnt))
 					last_saved_model_path = "Data/Models/model_translation_epoch_{}_{}.ckpt".format(i, cnt)
-					
-			
-			save_path = saver.save(sess, "Data/Models/model_translation_epoch_{}.ckpt".format(i))
+					saver.save(sess, last_saved_model_path)
+
 			last_saved_model_path = "Data/Models/model_translation_epoch_{}.ckpt".format(i)
+			saver.save(sess, last_saved_model_path)
 
 			tf.reset_default_graph()
 			sess.close()
-				
 
 if __name__ == '__main__':
 	main()

--- a/utils.py
+++ b/utils.py
@@ -3,12 +3,7 @@ import numpy as np
 def weighted_pick(weights):
 	t = np.cumsum(weights)
 	s = np.sum(weights)
-	return(int(np.searchsorted(t, np.random.rand(1)*s)))
-
+	return int(np.searchsorted(t, np.random.rand(1)*s))
 
 def list_to_string(ascii_list):
-	res = u""
-	for a in ascii_list:
-		if a >= 0 and a < 256:
-			res += chr(a)
-	return res
+	return "".join(chr(a) for a in ascii_list if 0 <= a < 256)

--- a/utils.py
+++ b/utils.py
@@ -10,5 +10,5 @@ def list_to_string(ascii_list):
 	res = u""
 	for a in ascii_list:
 		if a >= 0 and a < 256:
-			res += unichr(a)
+			res += chr(a)
 	return res


### PR DESCRIPTION
This pull request eliminates the warnings with the latest TensorFlow version. I have also refactored some functions for better readability. The code now requires Python 3, which lead to further simplifications.